### PR TITLE
feat: Implement QueryCommand CLI

### DIFF
--- a/app/Commands/QueryCommand.php
+++ b/app/Commands/QueryCommand.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Commands;
+
+use App\Services\KnowledgeAiService;
+use LaravelZero\Framework\Commands\Command;
+
+class QueryCommand extends Command
+{
+    protected $signature = 'query
+        {question : The question to ask}
+        {--model= : Explicit model (e.g., grok, claude, gemini, anthropic/claude-opus-4-6)}
+        {--consensus : Query multiple models and compare}
+        {--no-context : Skip knowledge fetching, pure AI query}
+        {--json : Output as JSON}
+        {--limit=10 : Max knowledge entries to include as context}';
+
+    protected $description = 'Query your knowledge base with AI enrichment';
+
+    public function handle(KnowledgeAiService $service): int
+    {
+        $question = $this->argument('question');
+        $model = $this->option('model');
+        $limit = (int) $this->option('limit');
+
+        if ($this->option('consensus')) {
+            return $this->handleConsensus($service, $question);
+        }
+
+        $this->output->write("\n");
+        $this->components->twoColumnDetail('<fg=cyan>Query</>', $question);
+
+        try {
+            if ($this->option('no-context')) {
+                $result = $service->queryDirect($question, $model);
+            } else {
+                $result = $service->query($question, $model, $limit);
+            }
+        } catch (\RuntimeException $e) {
+            $this->components->error($e->getMessage());
+
+            if (str_contains($e->getMessage(), 'Failed to create session') || str_contains($e->getMessage(), 'Connection refused')) {
+                $this->components->info('Is opencode serve running? Start it with: opencode serve');
+            }
+
+            return self::FAILURE;
+        }
+
+        $modelInfo = $result['model'];
+        $this->components->twoColumnDetail(
+            '<fg=cyan>Model</>',
+            "{$modelInfo['model']} ({$modelInfo['provider']}) [{$modelInfo['tier']}]"
+        );
+        $this->components->twoColumnDetail(
+            '<fg=cyan>Context</>',
+            "{$result['context_entries']} entries loaded"
+        );
+
+        $this->output->write("\n");
+
+        if ($this->option('json')) {
+            $this->line(json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+        } else {
+            $response = $result['response']['response'] ?? $result['response']['content'] ?? json_encode($result['response']);
+            $this->line($response);
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function handleConsensus(KnowledgeAiService $service, string $question): int
+    {
+        $this->output->write("\n");
+        $this->components->info("Consensus query: {$question}");
+        $this->output->write("\n");
+
+        try {
+            $result = $service->consensus($question);
+        } catch (\RuntimeException $e) {
+            $this->components->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        foreach ($result['responses'] as $modelName => $modelResult) {
+            $route = $modelResult['model'];
+            $this->components->twoColumnDetail(
+                "<fg=yellow>{$modelName}</>",
+                "{$route['model']} ({$route['provider']})"
+            );
+
+            if (isset($modelResult['error'])) {
+                $this->components->error("  Error: {$modelResult['error']}");
+            } else {
+                $response = $modelResult['response']['response'] ?? $modelResult['response']['content'] ?? json_encode($modelResult['response']);
+                $this->line($response);
+            }
+
+            $this->output->write("\n");
+        }
+
+        $this->components->twoColumnDetail(
+            '<fg=cyan>Models consulted</>',
+            (string) $result['models_consulted']
+        );
+
+        if ($this->option('json')) {
+            $this->line(json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,10 @@
 
 namespace App\Providers;
 
+use App\Services\KnowledgeAiService;
+use App\Services\ModelRouter;
+use App\Services\OpenCodeClient;
+use App\Services\PrefrontalClient;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +23,16 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->app->singleton(OpenCodeClient::class, fn () => OpenCodeClient::fromConfig());
+
+        $this->app->singleton(ModelRouter::class, fn () => new ModelRouter);
+
+        $this->app->singleton(PrefrontalClient::class, fn () => PrefrontalClient::fromConfig());
+
+        $this->app->singleton(KnowledgeAiService::class, fn ($app) => new KnowledgeAiService(
+            opencode: $app->make(OpenCodeClient::class),
+            router: $app->make(ModelRouter::class),
+            prefrontal: $app->make(PrefrontalClient::class),
+        ));
     }
 }

--- a/tests/Feature/QueryCommandTest.php
+++ b/tests/Feature/QueryCommandTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    Http::fake([
+        '*/session' => Http::response(['id' => 'test-session'], 200),
+        '*/session/test-session/prompt' => Http::response([
+            'response' => 'This is the AI response about your knowledge',
+        ], 200),
+        '*/filter*' => Http::response([
+            'entries' => [
+                ['title' => 'Test Entry', 'content' => 'Some knowledge', 'tags' => ['test']],
+            ],
+            'total' => 1,
+        ], 200),
+    ]);
+});
+
+it('queries knowledge with default routing', function () {
+    $this->artisan('query', ['question' => 'what is Laravel'])
+        ->assertExitCode(0);
+});
+
+it('accepts explicit model override', function () {
+    $this->artisan('query', ['question' => 'test question', '--model' => 'grok'])
+        ->assertExitCode(0);
+});
+
+it('runs consensus mode', function () {
+    $this->artisan('query', ['question' => 'best caching strategy', '--consensus' => true])
+        ->assertExitCode(0);
+});
+
+it('skips knowledge context with --no-context', function () {
+    $this->artisan('query', ['question' => 'generic question', '--no-context' => true])
+        ->assertExitCode(0);
+});
+
+it('outputs JSON when flag is set', function () {
+    $this->artisan('query', ['question' => 'test', '--json' => true])
+        ->assertExitCode(0);
+});
+
+it('respects limit option', function () {
+    $this->artisan('query', ['question' => 'test', '--limit' => '5'])
+        ->assertExitCode(0);
+});
+
+it('shows error when opencode is not running', function () {
+    $service = Mockery::mock(\App\Services\KnowledgeAiService::class);
+    $service->shouldReceive('query')
+        ->andThrow(new \RuntimeException('Failed to create session: 503'));
+
+    $this->app->instance(\App\Services\KnowledgeAiService::class, $service);
+
+    $this->artisan('query', ['question' => 'test'])
+        ->assertExitCode(1);
+});


### PR DESCRIPTION
## Summary
- **QueryCommand**: Primary CLI interface for knowledge + AI queries
  - Auto model routing by query intent
  - Explicit model override (`--model grok`)
  - Multi-model consensus (`--consensus`)
  - No-context mode for pure AI (`--no-context`)
  - JSON output for piping (`--json`)
  - Configurable context limit (`--limit`)
- **AppServiceProvider**: Proper singleton DI bindings for all services

Closes #5

## Test Plan
- [x] 7 new command tests
- [x] All 53 tests pass (104 assertions)
- [x] Error handling when opencode is down
- [x] Pint formatted